### PR TITLE
Fix typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ updater({
 
  ## Notice
 
-Please make sure you pacakge's initial version is bigger than `1.0.0`.
+Please make sure you packages's initial version is bigger than `1.0.0`.
 
 ## License
 


### PR DESCRIPTION
It was `pacakge` instead of `package`